### PR TITLE
PID Controls for Drivetrain

### DIFF
--- a/chargedUp/src/main/java/frc/robot/Constants.java
+++ b/chargedUp/src/main/java/frc/robot/Constants.java
@@ -18,5 +18,18 @@ public final class Constants {
   }
   public static class DrivetrainConstants{
     public static final int[] kDrivetrainCANIDs = new int[] {1,2,3,4};
+    public static final double kStopMotors = 0;
+
+    //PID Controlls for Forawrds and Backwards
+    public static final double kMoveP = 25;
+    public static final double kMoveI = 0;
+    public static final double kMoveD = 0;
+    public static final double kMoveTolerance = 1;
+
+    //PID Controlls for Turning
+    public static final double kTurnP = 0;
+    public static final double kTurnI = 0;
+    public static final double kTurnD = 0;
+    public static final double kTurnTolerance = 0;
   }
 }

--- a/chargedUp/src/main/java/frc/robot/RobotContainer.java
+++ b/chargedUp/src/main/java/frc/robot/RobotContainer.java
@@ -8,11 +8,13 @@ import frc.robot.Constants.OperatorConstants;
 import frc.robot.commands.Autos;
 import frc.robot.commands.ExampleCommand;
 import frc.robot.commands.targetFinding;
+import frc.robot.commands.DrivetrainPID.MovePID;
 import frc.robot.subsystems.DrivetrainSubsystem;
 import frc.robot.subsystems.ExampleSubsystem;
 import frc.robot.subsystems.VisionSubsystem;
 import edu.wpi.first.wpilibj.XboxController;
 import edu.wpi.first.wpilibj2.command.Command;
+import edu.wpi.first.wpilibj2.command.InstantCommand;
 import edu.wpi.first.wpilibj2.command.RunCommand;
 import edu.wpi.first.wpilibj2.command.button.CommandXboxController;
 import edu.wpi.first.wpilibj2.command.button.JoystickButton;
@@ -56,7 +58,18 @@ public class RobotContainer {
    */
   private void configureBindings() {
     //Spins Motor if April Tags are Recognized for 20 Ticks
-    new JoystickButton(m_driverController, XboxController.Button.kA.value).onTrue(new targetFinding(m_drivetrainSubsystem, m_visionSubsystem));
+    new JoystickButton(m_driverController, XboxController.Button.kA.value).
+    onTrue(new targetFinding(m_drivetrainSubsystem, m_visionSubsystem));
+
+    new JoystickButton(m_driverController, XboxController.Button.kB.value).
+    onTrue(new MovePID(m_drivetrainSubsystem, 10.0));
+
+    new JoystickButton(m_driverController, XboxController.Button.kY.value).
+    onTrue(new MovePID(m_drivetrainSubsystem, 30.0));
+
+    new JoystickButton(m_driverController, XboxController.Button.kX.value).
+    onTrue(new InstantCommand(() ->
+    m_drivetrainSubsystem.resetPosition()));
 
   }
 

--- a/chargedUp/src/main/java/frc/robot/commands/DrivetrainPID/MovePID.java
+++ b/chargedUp/src/main/java/frc/robot/commands/DrivetrainPID/MovePID.java
@@ -1,0 +1,47 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package frc.robot.commands.DrivetrainPID;
+
+import edu.wpi.first.math.controller.PIDController;
+import edu.wpi.first.wpilibj2.command.PIDCommand;
+import frc.robot.Constants.DrivetrainConstants;
+import frc.robot.subsystems.DrivetrainSubsystem;
+
+// NOTE:  Consider using this command inline, rather than writing a subclass.  For more
+// information, see:
+// https://docs.wpilib.org/en/stable/docs/software/commandbased/convenience-features.html
+public class MovePID extends PIDCommand {
+  /** Creates a new MovePID. */
+  DrivetrainSubsystem m_drivetrainSubsystem;
+  public MovePID(DrivetrainSubsystem drive, Double setpoint) {
+    super(
+        // The controller that the command will use
+        new PIDController(DrivetrainConstants.kMoveP, DrivetrainConstants.kMoveI, DrivetrainConstants.kMoveD),
+        // This should return the measurement
+        () -> drive.getPosition(),
+        // This should return the setpoint (can also be a constant)
+        () -> setpoint,
+        // This uses the output
+        output -> { drive.setRaw(output/180, DrivetrainConstants.kStopMotors); //Divides by 180 to make output in between -1 and 1
+          // Use the output here
+        });
+    // Use addRequirements() here to declare subsystem dependencies.
+    // Configure additional PID options by calling `getController` here.
+    m_drivetrainSubsystem = drive;
+    addRequirements(m_drivetrainSubsystem);
+
+    getController().setTolerance(DrivetrainConstants.kMoveTolerance);
+  }
+
+  @Override
+  public void initialize() {
+    m_drivetrainSubsystem.resetPosition();
+  }
+  // Returns true when the command should end.
+  @Override
+  public boolean isFinished() {
+    return (getController().atSetpoint() == true);
+  }
+}

--- a/chargedUp/src/main/java/frc/robot/commands/DrivetrainPID/TurnPID.java
+++ b/chargedUp/src/main/java/frc/robot/commands/DrivetrainPID/TurnPID.java
@@ -1,0 +1,51 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package frc.robot.commands.DrivetrainPID;
+
+import edu.wpi.first.math.controller.PIDController;
+import edu.wpi.first.wpilibj2.command.PIDCommand;
+import frc.robot.Constants.DrivetrainConstants;
+import frc.robot.subsystems.DrivetrainSubsystem;
+import frc.robot.subsystems.GyroSubsystem;
+
+// NOTE:  Consider using this command inline, rather than writing a subclass.  For more
+// information, see:
+// https://docs.wpilib.org/en/stable/docs/software/commandbased/convenience-features.html
+public class TurnPID extends PIDCommand {
+  /** Creates a new TurnPID. */
+  DrivetrainSubsystem m_drivetrainSubsystem;
+  GyroSubsystem m_gyroSubsystem;
+  public TurnPID(DrivetrainSubsystem drive, GyroSubsystem gyro, double targetAngle) {
+    super(
+        // The controller that the command will use
+        new PIDController(DrivetrainConstants.kTurnP, DrivetrainConstants.kTurnI, DrivetrainConstants.kTurnD),
+        // This should return the measurement
+        () -> gyro.getAngle(),
+        // This should return the setpoint (can also be a constant)
+        () -> targetAngle,
+        // This uses the output
+        output -> { drive.setRaw(DrivetrainConstants.kStopMotors, output/180); //Divides by 180 to make output in between -1 and 1
+          // Use the output here
+        });
+    // Use addRequirements() here to declare subsystem dependencies.
+    // Configure additional PID options by calling `getController` here
+    m_drivetrainSubsystem = drive;
+    m_gyroSubsystem = gyro;
+    addRequirements(m_drivetrainSubsystem, m_gyroSubsystem);
+
+    getController().enableContinuousInput(-180, 180);
+    getController().setTolerance(DrivetrainConstants.kMoveTolerance);
+  }
+
+  @Override
+  public void initialize() {
+    m_gyroSubsystem.resetYaw();
+  }
+  // Returns true when the command should end.
+  @Override
+  public boolean isFinished() {
+    return (getController().atSetpoint() == true);
+  }
+}

--- a/chargedUp/src/main/java/frc/robot/subsystems/DrivetrainSubsystem.java
+++ b/chargedUp/src/main/java/frc/robot/subsystems/DrivetrainSubsystem.java
@@ -7,6 +7,7 @@ package frc.robot.subsystems;
 import com.revrobotics.CANSparkMax;
 import com.revrobotics.RelativeEncoder;
 import com.revrobotics.SparkMaxRelativeEncoder;
+import com.revrobotics.CANSparkMax.IdleMode;
 import com.revrobotics.CANSparkMaxLowLevel.MotorType;
 
 import edu.wpi.first.wpilibj.drive.DifferentialDrive;
@@ -36,6 +37,7 @@ public class DrivetrainSubsystem extends SubsystemBase {
     // leftFollower = new CANSparkMax(Constants.DrivetrainConstants.kDrivetrainCANIDs[2], MotorType.kBrushless);
     // rightFollower = new CANSparkMax(Constants.DrivetrainConstants.kDrivetrainCANIDs[3], MotorType.kBrushless);
 
+    leftLead.setIdleMode(IdleMode.kBrake);
     encoderLeftLead = leftLead.getEncoder();
     // leftFollower.follow(leftLead);
 
@@ -53,6 +55,10 @@ public class DrivetrainSubsystem extends SubsystemBase {
 
   public double getPosition(){
     return encoderLeftLead.getPosition();
+  }
+
+  public void resetPosition(){
+    encoderLeftLead.setPosition(0);
   }
   
   @Override

--- a/chargedUp/src/main/java/frc/robot/subsystems/GyroSubsystem.java
+++ b/chargedUp/src/main/java/frc/robot/subsystems/GyroSubsystem.java
@@ -1,0 +1,31 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package frc.robot.subsystems;
+
+import com.kauailabs.navx.frc.AHRS;
+import edu.wpi.first.wpilibj.SPI;
+
+import edu.wpi.first.wpilibj2.command.SubsystemBase;
+
+public class GyroSubsystem extends SubsystemBase {
+  /** Creates a new GyroSubsystem. */
+  AHRS m_gyro;
+  public GyroSubsystem() {
+    m_gyro = new AHRS(SPI.Port.kMXP) ;
+  }
+
+  public double getAngle(){
+    return m_gyro.getAngle();
+  }
+
+  public void resetYaw(){
+    m_gyro.zeroYaw();
+  }
+
+  @Override
+  public void periodic() {
+    // This method will be called once per scheduler run
+  }
+}

--- a/chargedUp/src/main/java/frc/robot/subsystems/VisionSubsystem.java
+++ b/chargedUp/src/main/java/frc/robot/subsystems/VisionSubsystem.java
@@ -39,10 +39,6 @@ public class VisionSubsystem extends SubsystemBase {
     return results.hasTargets();
   }
 
-  // public List<PhotonTrackedTarget> identifyTags(){
-  //   return results.getTargets();
-  // }
-
   public int getBestFiducial(){
     return (this.seeTarget() == true) ? results.getBestTarget().getFiducialId() : 0;
   }

--- a/chargedUp/vendordeps/NavX.json
+++ b/chargedUp/vendordeps/NavX.json
@@ -1,0 +1,39 @@
+{
+    "fileName": "NavX.json",
+    "name": "KauaiLabs_navX_FRC",
+    "version": "2023.0.3",
+    "uuid": "cb311d09-36e9-4143-a032-55bb2b94443b",
+    "mavenUrls": [
+        "https://dev.studica.com/maven/release/2023/"
+    ],
+    "jsonUrl": "https://dev.studica.com/releases/2023/NavX.json",
+    "javaDependencies": [
+        {
+            "groupId": "com.kauailabs.navx.frc",
+            "artifactId": "navx-frc-java",
+            "version": "2023.0.3"
+        }
+    ],
+    "jniDependencies": [],
+    "cppDependencies": [
+        {
+            "groupId": "com.kauailabs.navx.frc",
+            "artifactId": "navx-frc-cpp",
+            "version": "2023.0.3",
+            "headerClassifier": "headers",
+            "sourcesClassifier": "sources",
+            "sharedLibrary": false,
+            "libName": "navx_frc",
+            "skipInvalidPlatforms": true,
+            "binaryPlatforms": [
+                "linuxathena",
+                "linuxraspbian",
+                "linuxarm32",
+                "linuxarm64",
+                "linux86-64",
+                "osxuniversal",
+                "windowsx86-64"
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
This introduces PID Controls for the drivetrain by having separate commands for the output for moving and turning. The PID Constants are updated for the Electrical Board, not the Chassis.